### PR TITLE
Fixed a link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ I really needed a visual tool which I could use to search for assets on a certai
 
 # How to use
 
-You just [load the page](https://artusvranken.github.io/bigchaindb-snooper) and start typing a string you want to query! Click on an asset to get a list of transactions and click on a transaction to get a detailed overview of its data.
+You just [load the page](https://artus.github.io/bigchaindb-snooper/) and start typing a string you want to query! Click on an asset to get a list of transactions and click on a transaction to get a detailed overview of its data.
 
 By default, the snooper will point to the [official BigchainDB Testnet](https://testnet.bigchaindb.com/), but you can point it to any node by changing the URL in the settings pane.


### PR DESCRIPTION
I fixed the link to the demo site in the root README.md file. It was linking to https://artusvranken.github.io/bigchaindb-snooper and I changed it to link to https://artus.github.io/bigchaindb-snooper/

I'm not sure why GitHub is saying I changed the last line. I didn't.